### PR TITLE
feat: added pre-wired rule for icd-databases

### DIFF
--- a/examples/fscloud/README.md
+++ b/examples/fscloud/README.md
@@ -9,7 +9,7 @@ This examples is designed to show case some of the key customization options for
 4. Open up network traffic flow from the VPC created in this example to ICD postgresql private endpoints.
 
 Context: this examples covers a "pseudo" real-world scenario where:
-1. ICD Mongodb, and Postgresql instances are encrypted using keys storage in Key Protect.
+1. ICD Mongodb and Postgresql instances are encrypted using keys storage in Key Protect.
 2. Schematics is used to execute terraform that create Key Protect keys and key ring over its public endpoint.
 3. Operators use machines with a set list of public IPs to interact with Schematics.
 4. Applications are running the VPC and need access to PostgreSQL via the private endpoint - eg: a VPE.

--- a/examples/fscloud/README.md
+++ b/examples/fscloud/README.md
@@ -3,10 +3,10 @@
 This example demonstrates how to use the [fscloud profile](../../profiles/fscloud/) module to lay out a complete "secure by default" coarse-grained CBR topology in a given account.
 
 This examples is designed to show case some of the key customization options for the module. In addition to the pre-wired CBR rules documented at [fscloud profile](../../profiles/fscloud/), this examples show how to customize the module to:
-1. Open up network traffic flow from ICD mongodb, ICD Postgresql to the Key Protect private endpoints
-2. Open up network traffic flow from Schematics to Key Protect public endpoints
-3. Open up network traffic flow from a block of IPs to the Schematics public endpoint
-4. Open up network traffic flow from the VPC created in this example to ICD postgresql private endpoints
+1. Open up network traffic flow from ICD mongodb, ICD Postgresql to the Key Protect private endpoints.
+2. Open up network traffic flow from Schematics to Key Protect public endpoints.
+3. Open up network traffic flow from a block of IPs to the Schematics public endpoint.
+4. Open up network traffic flow from the VPC created in this example to ICD postgresql private endpoints.
 
 Context: this examples covers a "pseudo" real-world scenario where:
 1. ICD Mongodb, and Postgresql instances are encrypted using keys storage in Key Protect.

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -65,6 +65,7 @@ module "cbr_account_level" {
   allow_cos_to_kms                 = var.allow_cos_to_kms
   allow_block_storage_to_kms       = var.allow_block_storage_to_kms
   allow_roks_to_kms                = var.allow_roks_to_kms
+  allow_icd_to_kms                 = var.allow_icd_to_kms
   allow_vpcs_to_container_registry = var.allow_vpcs_to_container_registry
   allow_vpcs_to_cos                = var.allow_vpcs_to_cos
 

--- a/examples/fscloud/variables.tf
+++ b/examples/fscloud/variables.tf
@@ -37,12 +37,18 @@ variable "allow_cos_to_kms" {
 variable "allow_block_storage_to_kms" {
   type        = bool
   description = "Set rule for block storage to KMS, deafult is true"
-  default     = true
+  default     = false
 }
 
 variable "allow_roks_to_kms" {
   type        = bool
   description = "Set rule for ROKS to KMS, deafult is true"
+  default     = true
+}
+
+variable "allow_icd_to_kms" {
+  type        = bool
+  description = "Set rule for ICD to KMS, deafult is true"
   default     = true
 }
 

--- a/examples/fscloud/variables.tf
+++ b/examples/fscloud/variables.tf
@@ -37,7 +37,7 @@ variable "allow_cos_to_kms" {
 variable "allow_block_storage_to_kms" {
   type        = bool
   description = "Set rule for block storage to KMS, deafult is true"
-  default     = false
+  default     = true
 }
 
 variable "allow_roks_to_kms" {

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -47,6 +47,7 @@ The services 'compliance', 'directlink', 'iam-groups', 'containers-kubernetes', 
 |------|-------------|------|---------|:--------:|
 | <a name="input_allow_block_storage_to_kms"></a> [allow\_block\_storage\_to\_kms](#input\_allow\_block\_storage\_to\_kms) | Set rule for block storage to KMS, deafult is true | `bool` | `true` | no |
 | <a name="input_allow_cos_to_kms"></a> [allow\_cos\_to\_kms](#input\_allow\_cos\_to\_kms) | Set rule for COS to KMS, deafult is true | `bool` | `true` | no |
+| <a name="input_allow_icd_to_kms"></a> [allow\_icd\_to\_kms](#input\_allow\_icd\_to\_kms) | Set rule for ICD to KMS, deafult is true | `bool` | `true` | no |
 | <a name="input_allow_roks_to_kms"></a> [allow\_roks\_to\_kms](#input\_allow\_roks\_to\_kms) | Set rule for ROKS to KMS, deafult is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_container_registry"></a> [allow\_vpcs\_to\_container\_registry](#input\_allow\_vpcs\_to\_container\_registry) | Set rule for VPCs to container registry, deafult is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_cos"></a> [allow\_vpcs\_to\_cos](#input\_allow\_vpcs\_to\_cos) | Set rule for VPCs to COS, deafult is true | `bool` | `true` | no |

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -4,9 +4,10 @@ This module creates default coarse-grained CBR rules in a given account followin
 - COS -> KMS
 - Block storage -> KMS
 - ROKS -> KMS
-- Activity Tracker route -> COS (pending addition of AT as zone)
-- VPCs -> container registry
+- Activity Tracker route -> COS
 - VPCs where clusters are deployed -> COS
+- VPCs -> container registry
+- All ICD -> KMS
 
 This module is designed to allow the consumer to add additional custom rules to open up additional flows necessarity for their usage. See the `custom_rule_contexts_by_service` input variable, and an [usage example](../../examples/fscloud/) demonstrating how to open up more flows.
 

--- a/modules/fscloud/variables.tf
+++ b/modules/fscloud/variables.tf
@@ -26,6 +26,12 @@ variable "allow_roks_to_kms" {
   default     = true
 }
 
+variable "allow_icd_to_kms" {
+  type        = bool
+  description = "Set rule for ICD to KMS, deafult is true"
+  default     = true
+}
+
 variable "allow_vpcs_to_container_registry" {
   type        = bool
   description = "Set rule for VPCs to container registry, deafult is true"


### PR DESCRIPTION
### Description

Added pre-wired rules to enable below ICD databases to talk to KMS.

- databases-for-cassandra     
- databases-for-elasticsearch  
- databases-for-enterprisedb  
- databases-for-etcd            
- databases-for-mongodb     
- databases-for-mysql        
- databases-for-postgresql     
- databases-for-redis

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
