### PR TITLE
test: modified pr_test and moved fscloud to other test

### DIFF
--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -14,9 +14,9 @@ func TestFSCloudExample(t *testing.T) {
 	t.Parallel()
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  fsCloudTerraformDir,
-		Prefix:        "cbr-fs",
+		Testing:      t,
+		TerraformDir: fsCloudTerraformDir,
+		Prefix:       "cbr-fs",
 	})
 	output, err := options.RunTestConsistency()
 	assert.Nil(t, err, "This should not have errored")

--- a/tests/other_test.go
+++ b/tests/other_test.go
@@ -1,0 +1,24 @@
+// Tests in this file are NOT run in the PR pipeline. They are run in the continuous testing pipeline along with the ones in pr_test.go
+package test
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
+)
+
+const fsCloudTerraformDir = "examples/fscloud"
+
+func TestFSCloudExample(t *testing.T) {
+	t.Parallel()
+
+	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
+		Testing:       t,
+		TerraformDir:  fsCloudTerraformDir,
+		Prefix:        "cbr-fs",
+	})
+	output, err := options.RunTestConsistency()
+	assert.Nil(t, err, "This should not have errored")
+	assert.NotNil(t, output, "Expected some output")
+}

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -16,11 +16,9 @@ import (
 	"github.com/terraform-ibm-modules/ibmcloud-terratest-wrapper/testhelper"
 )
 
-const resourceGroup = "geretain-test-cbr"
 const zoneExampleTerraformDir = "examples/zone"
 const completeExampleTerraformDir = "examples/multizone-rule"
 const multiServiceExampleTerraformDir = "examples/multi-service-profile"
-const fsCloudTerraformDir = "examples/fscloud"
 const permanentResourcesYaml = "../common-dev-assets/common-go-assets/common-permanent-resources.yaml"
 
 func TestRunZoneExample(t *testing.T) {
@@ -29,10 +27,9 @@ func TestRunZoneExample(t *testing.T) {
 	assert.Nil(t, err, "Failed to create cloud info service")
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  zoneExampleTerraformDir,
-		Prefix:        "cbr-zone",
-		ResourceGroup: resourceGroup,
+		Testing:      t,
+		TerraformDir: zoneExampleTerraformDir,
+		Prefix:       "cbr-zone",
 	})
 	options.SkipTestTearDown = true
 	output, err := options.RunTestConsistency()
@@ -83,10 +80,9 @@ func TestRunCompleteExample(t *testing.T) {
 		}
 
 		options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-			Testing:       t,
-			TerraformDir:  completeExampleTerraformDir,
-			Prefix:        "cbr-multizone",
-			ResourceGroup: resourceGroup,
+			Testing:      t,
+			TerraformDir: completeExampleTerraformDir,
+			Prefix:       "cbr-multizone",
 			TerraformVars: map[string]interface{}{
 				"existing_access_tags": accessTags,
 			},
@@ -203,10 +199,9 @@ func TestMultiServiceProfileExample(t *testing.T) {
 	assert.Nil(t, err, "Failed to create cloud info service")
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  multiServiceExampleTerraformDir,
-		Prefix:        "cbr-multi-service-profile",
-		ResourceGroup: resourceGroup,
+		Testing:      t,
+		TerraformDir: multiServiceExampleTerraformDir,
+		Prefix:       "cbr-multi-service-profile",
 	})
 	options.SkipTestTearDown = true
 	output, err := options.RunTestConsistency()
@@ -289,28 +284,13 @@ func TestMultiServiceProfileExample(t *testing.T) {
 	options.TestTearDown()
 }
 
-func TestFSCloudExample(t *testing.T) {
-	t.Parallel()
-
-	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  fsCloudTerraformDir,
-		Prefix:        "cbr-fs",
-		ResourceGroup: resourceGroup,
-	})
-	output, err := options.RunTestConsistency()
-	assert.Nil(t, err, "This should not have errored")
-	assert.NotNil(t, output, "Expected some output")
-}
-
 func TestRunUpgradeExample(t *testing.T) {
 	t.Parallel()
 
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
-		Testing:       t,
-		TerraformDir:  zoneExampleTerraformDir,
-		Prefix:        "cbr-upg",
-		ResourceGroup: resourceGroup,
+		Testing:      t,
+		TerraformDir: zoneExampleTerraformDir,
+		Prefix:       "cbr-upg",
 	})
 
 	output, err := options.RunTestUpgrade()

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -201,7 +201,7 @@ func TestMultiServiceProfileExample(t *testing.T) {
 	options := testhelper.TestOptionsDefaultWithVars(&testhelper.TestOptions{
 		Testing:      t,
 		TerraformDir: multiServiceExampleTerraformDir,
-		Prefix:       "cbr-multi-service-profile",
+		Prefix:       "cbr-msp",
 	})
 	options.SkipTestTearDown = true
 	output, err := options.RunTestConsistency()


### PR DESCRIPTION
### Description

- Removed the RG from the pr test so that the target services will be scoped to newly created RGs.
- Moved the FScloud example to other test so that it does not clash with other PRs.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [x] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### Merge actions for mergers

- When merging, use a relevant [conventional commit](https://www.conventionalcommits.org/) message that is based on the PR contents and any release notes provided by the PR author. The commit message determines whether a new version of the module is needed, and if so, which semver increment to use (major, minor, or patch).
- Merge by using "Squash and merge".
