### PR TITLE
fix: update fscloud submodule to require >= 1.56.1 of ibm provider

### DIFF
--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -68,7 +68,7 @@ module "cbr_fscloud" {
 | Name | Version |
 |------|---------|
 | <a name="requirement_terraform"></a> [terraform](#requirement\_terraform) | >= 1.3.0, <1.6.0 |
-| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | 1.56.1 |
+| <a name="requirement_ibm"></a> [ibm](#requirement\_ibm) | >=1.56.1 |
 
 ### Modules
 
@@ -83,7 +83,7 @@ module "cbr_fscloud" {
 
 | Name | Type |
 |------|------|
-| [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/1.56.1/docs/data-sources/iam_account_settings) | data source |
+| [ibm_iam_account_settings.iam_account_settings](https://registry.terraform.io/providers/IBM-Cloud/ibm/latest/docs/data-sources/iam_account_settings) | data source |
 
 ### Inputs
 

--- a/modules/fscloud/version.tf
+++ b/modules/fscloud/version.tf
@@ -1,10 +1,9 @@
 terraform {
   required_version = ">= 1.3.0, <1.6.0"
   required_providers {
-    # Pin to the lowest provider version of the range defined in the main module's version.tf to ensure lowest version still works
     ibm = {
       source  = "IBM-Cloud/ibm"
-      version = "1.56.1"
+      version = ">=1.56.1"
     }
   }
 }


### PR DESCRIPTION
### Description

update fscloud submodule to require >= 1.56.0 of ibm provider

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
