### PR TITLE
fix: updated multiservice example

### DIFF
--- a/examples/multi-service-profile/variables.tf
+++ b/examples/multi-service-profile/variables.tf
@@ -36,7 +36,7 @@ variable "resource_tags" {
 
 variable "zone_service_ref_list" {
   type        = list(string)
-  default     = ["cloud-object-storage", "containers-kubernetes", "server-protect"]
+  default     = ["cloud-object-storage", "server-protect"]
   description = "(List) Service reference for the zone creation"
 }
 

--- a/examples/multi-service-profile/variables.tf
+++ b/examples/multi-service-profile/variables.tf
@@ -7,7 +7,7 @@ variable "ibmcloud_api_key" {
 variable "prefix" {
   type        = string
   description = "Prefix to append to all resources created by this example"
-  default     = "test-terraform-multizone"
+  default     = "test-terraform-multiservice"
 }
 
 variable "region" {
@@ -19,7 +19,7 @@ variable "region" {
 variable "location" {
   description = "The region in which the network zone is scoped"
   type        = string
-  default     = "us-south"
+  default     = "dal" # dal metro is the equivalent location for the us-south region
 }
 
 variable "resource_group" {

--- a/modules/cbr-service-profile/README.md
+++ b/modules/cbr-service-profile/README.md
@@ -49,7 +49,7 @@ module "cbr_rule_multi_service_profile" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | List specific endpoint types for target services, valid values for endpoints are 'public', 'private' or 'direct' | `list(string)` | <pre>[<br>  "private"<br>]</pre> | no |
-| <a name="input_location"></a> [location](#input\_location) | The region in which the network zone is scoped | `string` | `"us-south"` | no |
+| <a name="input_location"></a> [location](#input\_location) | The region in which the network zone is scoped | `string` | `null` | no |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to append to all vpc\_zone\_list, service\_ref\_zone\_list and cbr\_rule\_description created by this submodule | `string` | `"serviceprofile"` | no |
 | <a name="input_target_service_details"></a> [target\_service\_details](#input\_target\_service\_details) | (String) Details of the target service for which the rule has to be created | <pre>list(object({<br>    target_service_name = string<br>    target_rg           = optional(string)<br>    enforcement_mode    = string<br>    tags                = optional(list(string))<br>  }))</pre> | n/a | yes |
 | <a name="input_zone_service_ref_list"></a> [zone\_service\_ref\_list](#input\_zone\_service\_ref\_list) | (List) Service reference for the zone creation | `list(string)` | `[]` | no |

--- a/modules/cbr-service-profile/README.md
+++ b/modules/cbr-service-profile/README.md
@@ -49,7 +49,7 @@ module "cbr_rule_multi_service_profile" {
 | Name | Description | Type | Default | Required |
 |------|-------------|------|---------|:--------:|
 | <a name="input_endpoints"></a> [endpoints](#input\_endpoints) | List specific endpoint types for target services, valid values for endpoints are 'public', 'private' or 'direct' | `list(string)` | <pre>[<br>  "private"<br>]</pre> | no |
-| <a name="input_location"></a> [location](#input\_location) | The region in which the network zone is scoped | `string` | `null` | no |
+| <a name="input_location"></a> [location](#input\_location) | The region in which the network zone is scoped | `string` | n/a | yes |
 | <a name="input_prefix"></a> [prefix](#input\_prefix) | Prefix to append to all vpc\_zone\_list, service\_ref\_zone\_list and cbr\_rule\_description created by this submodule | `string` | `"serviceprofile"` | no |
 | <a name="input_target_service_details"></a> [target\_service\_details](#input\_target\_service\_details) | (String) Details of the target service for which the rule has to be created | <pre>list(object({<br>    target_service_name = string<br>    target_rg           = optional(string)<br>    enforcement_mode    = string<br>    tags                = optional(list(string))<br>  }))</pre> | n/a | yes |
 | <a name="input_zone_service_ref_list"></a> [zone\_service\_ref\_list](#input\_zone\_service\_ref\_list) | (List) Service reference for the zone creation | `list(string)` | `[]` | no |

--- a/modules/cbr-service-profile/main.tf
+++ b/modules/cbr-service-profile/main.tf
@@ -12,7 +12,7 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   validate_zone_inputs = ((length(var.zone_vpc_crn_list) == 0) && (length(var.zone_service_ref_list) == 0)) ? tobool("Error: Provide a valid zone vpc and/or service references") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_location_and_service_name = (length(setintersection(["compliance", "directlink", "iam-groups", "containers-kubernetes", "user-management"], var.zone_service_ref_list)) > 0 && var.location != null && var.location != null) ? tobool("Error: The services 'compliance','directlink','iam-groups','containers-kubernetes','user-management' does not support location") : true
+  validate_location_and_service_name = (length(setintersection(["compliance", "directlink", "iam-groups", "containers-kubernetes", "user-management"], var.zone_service_ref_list)) > 0 && var.location != null) ? tobool("Error: The services 'compliance','directlink','iam-groups','containers-kubernetes','user-management' does not support location") : true
 
 
 

--- a/modules/cbr-service-profile/main.tf
+++ b/modules/cbr-service-profile/main.tf
@@ -12,7 +12,9 @@ locals {
   # tflint-ignore: terraform_unused_declarations
   validate_zone_inputs = ((length(var.zone_vpc_crn_list) == 0) && (length(var.zone_service_ref_list) == 0)) ? tobool("Error: Provide a valid zone vpc and/or service references") : true
   # tflint-ignore: terraform_unused_declarations
-  validate_location_and_service_name = ((contains(["compliance", "directlink", "iam-groups", "containers-kubernetes", "user-management"], var.zone_service_ref_list)) && var.location != null) ? tobool("Error: The services 'compliance','directlink','iam-groups','containers-kubernetes','user-management' does not support location") : true
+  validate_location_and_service_name = (length(setintersection(["compliance", "directlink", "iam-groups", "containers-kubernetes", "user-management"], var.zone_service_ref_list)) > 0 && var.location != null && var.location != null) ? tobool("Error: The services 'compliance','directlink','iam-groups','containers-kubernetes','user-management' does not support location") : true
+
+
 
   # Restrict and allow the api types as per the target service
   icd_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:data-plane"]
@@ -58,7 +60,6 @@ locals {
 
   zone_list = concat(tolist(local.vpc_zone_list), tolist(local.service_ref_zone_list))
 }
-
 module "cbr_zone" {
   count            = length(local.zone_list)
   source           = "../cbr-zone-module"

--- a/modules/cbr-service-profile/variables.tf
+++ b/modules/cbr-service-profile/variables.tf
@@ -38,7 +38,6 @@ variable "zone_service_ref_list" {
 variable "location" {
   type        = string
   description = "The region in which the network zone is scoped"
-  default     = null
 }
 
 variable "target_service_details" {

--- a/modules/cbr-service-profile/variables.tf
+++ b/modules/cbr-service-profile/variables.tf
@@ -38,7 +38,7 @@ variable "zone_service_ref_list" {
 variable "location" {
   type        = string
   description = "The region in which the network zone is scoped"
-  default     = "us-south"
+  default     = null
 }
 
 variable "target_service_details" {

--- a/tests/pr_test.go
+++ b/tests/pr_test.go
@@ -211,7 +211,7 @@ func TestMultiServiceProfileExample(t *testing.T) {
 				t.Run("verify service reference exist", func(t *testing.T) {
 					var serviceRefExists bool
 					var actual_references []string
-					expected_references := []string{"cloud-object-storage", "containers-kubernetes", "server-protect"}
+					expected_references := []string{"cloud-object-storage", "server-protect"}
 
 					zoneIds := zones[0].([]interface{})
 					for index := range zoneIds {


### PR DESCRIPTION
### Description

Updated multiservice example with the correct location and corrected variable validation logic.
More info here at slack [discussion](https://ibm-cloudplatform.slack.com/archives/C01U169P12P/p1711554577664749?thread_ts=1711550096.016699&cid=C01U169P12P).

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

This release fixes the multi-service-profile example with location update.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
