### PR TITLE
fix: EN enforcement mode

### DIFF
--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -85,6 +85,10 @@ module "cbr_account_level" {
       "target_rg"        = module.resource_group.resource_group_id
       "global_deny"      = false
     }
+    "mqcloud" : {
+      "enforcement_mode" = "disabled"
+      "region"           = "eu-fr2"
+    },
   }
 
   # Demonstrates how a customized name can be set for the CBR zone

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -87,8 +87,8 @@ module "cbr_account_level" {
     }
     "mqcloud" : {
       "enforcement_mode" = "disabled"
-      "region"           = "eu-fr2"
-    },
+      "region"           = "eu-fr2" 
+    }
   }
 
   # Demonstrates how a customized name can be set for the CBR zone

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -87,7 +87,7 @@ module "cbr_account_level" {
     }
     "mqcloud" : {
       "enforcement_mode" = "disabled"
-      "region"           = "eu-fr2" 
+      "region"           = "eu-fr2" # BNPP region (eu-fr2)
     }
   }
 

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -87,7 +87,7 @@ module "cbr_account_level" {
     }
     "mqcloud" : {
       "enforcement_mode" = "disabled"
-      "region"           = "eu-fr2" # BNPP region (eu-fr2)
+      "region"           = "eu-fr2" # BNPP region
     }
   }
 

--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -88,6 +88,7 @@ module "cbr_account_level" {
     "mqcloud" : {
       "enforcement_mode" = "disabled"
       "region"           = "eu-fr2" # BNPP region
+      "global_deny"      = false
     }
   }
 

--- a/modules/cbr-service-profile/main.tf
+++ b/modules/cbr-service-profile/main.tf
@@ -29,7 +29,8 @@ locals {
     databases-for-mongodb       = local.icd_api_types,
     databases-for-postgresql    = local.icd_api_types,
     databases-for-redis         = local.icd_api_types,
-    messages-for-rabbitmq       = local.icd_api_types
+    messages-for-rabbitmq       = local.icd_api_types,
+    mqcloud                     = local.icd_api_types
   }
 
   vpc_zone_list = (length(var.zone_vpc_crn_list) > 0) ? [{

--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -24,6 +24,8 @@ The module also pre-create CBR zone for each service in the account as a best pr
 
 Important: In order to avoid unexpected breakage in the account against which this module is executed, the CBR rule enforcement mode is set to 'report' (or 'disabled' for services not supporting 'report' mode) by default. It is recommended to test out this module first with these default, and then use the `target_service_details` variable to set the enforcement mode to "enabled" gradually by service. The [usage example](../../examples/fscloud/) demonstrates how to set the enforcement mode to 'enabled' for the key protect ("kms") service.
 
+**Note on Event Notifications**: Event Notifications introduced SMTP API that does not support `report` enforcement mode. By default `report` mode is set which excludes SMTP API. If enforcement mode is set to `enabled`, CBR will be applied to the SMTP API as well.
+
 ## Note
 The services 'directlink', 'globalcatalog-collection', 'iam-groups' and 'user-management' does not support restriction per location.
 

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -401,6 +401,10 @@ module "cbr_rule" {
       # lookup the map for the target service name, if empty then pass default value
       for apitype in lookup(local.operations_apitype_val, each.key, []) : {
         api_type_id = apitype
+    }] # Addding condition below for Event Notifications to enable CBR for control plane API explicitly as SMTP API does not support report mode
+    }] : each.key == "event-notifications" && each.value.enforcement_mode == "report" ? [{
+    api_types = [{
+      api_type_id = "crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"
     }]
     }] : [{
     api_types = [{

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -345,6 +345,7 @@ locals {
     databases-for-redis              = local.icd_api_types,
     messages-for-rabbitmq            = local.icd_api_types,
     databases-for-mysql              = local.icd_api_types
+    mqcloud                          = local.icd_api_types
   }
 
   fake_service_names = {
@@ -401,7 +402,7 @@ module "cbr_rule" {
       # lookup the map for the target service name, if empty then pass default value
       for apitype in lookup(local.operations_apitype_val, each.key, []) : {
         api_type_id = apitype
-    }] # Addding condition below for Event Notifications to enable CBR for control plane API explicitly as SMTP API does not support report mode
+    }] # Addding condition below for Event Notifications to enable CBR for control plane API explicitly for report mode as SMTP API does not support report mode
     }] : each.key == "event-notifications" && each.value.enforcement_mode == "report" ? [{
     api_types = [{
       api_type_id = "crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"


### PR DESCRIPTION
### Description

- Added fix for Event Notification to support report mode.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/482)
- Added MQ segmentation to add data plane API type id.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/480)

### Release required?

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Event Notifications introduced SMTP API that does not support `report` enforcement mode. By default `report` mode is set which excludes SMTP API. If enforcement mode is set to `enabled`, CBR will be applied to the SMTP API as well.
- Added MQ segmentation to add data plane API type id.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
