### PR TITLE
fix: enforcement mode is disabled for EN

### DIFF
--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -24,7 +24,7 @@ The module also pre-create CBR zone for each service in the account as a best pr
 
 Important: In order to avoid unexpected breakage in the account against which this module is executed, the CBR rule enforcement mode is set to 'report' (or 'disabled' for services not supporting 'report' mode) by default. It is recommended to test out this module first with these default, and then use the `target_service_details` variable to set the enforcement mode to "enabled" gradually by service. The [usage example](../../examples/fscloud/) demonstrates how to set the enforcement mode to 'enabled' for the key protect ("kms") service.
 
-**Note on Event Notifications**: Event Notifications introduced SMTP API that does not support `report` enforcement mode. By default `report` mode is set which excludes SMTP API. If enforcement mode is set to `enabled`, CBR will be applied to the SMTP API as well.
+**Note on Event Notifications**: By default, `disabled` enforcement mode is set for Event Notifications as the SMTP API does not support `report` enforcement mode.
 
 **Note on global_deny variable**: When a `scope` is specified in a rule for the target service, a new separate `global rule` will be created for the respective target service to scope `all the resources` of that service. This can be opted out by setting the variable `global_deny = false`. It is also mandatory to set `global_deny = false` when no scope is specified for the target service.
 

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -94,7 +94,7 @@ locals {
       "enforcement_mode" : "report"
     },
     "event-notifications" : {
-      "enforcement_mode" : "report"
+      "enforcement_mode" : "disabled"
     },
     "compliance" : {
       "enforcement_mode" : "report"
@@ -397,10 +397,6 @@ module "cbr_rule" {
       # lookup the map for the target service name, if empty then pass default value
       for apitype in lookup(local.operations_apitype_val, each.key, []) : {
         api_type_id = apitype
-    }] # Addding condition below for Event Notifications to enable CBR for control plane API explicitly for report mode as SMTP API does not support report mode
-    }] : each.key == "event-notifications" && each.value.enforcement_mode == "report" ? [{
-    api_types = [{
-      api_type_id = "crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"
     }]
     }] : [{
     api_types = [{


### PR DESCRIPTION
### Description

Setting enforcement mode as disabled for EN, as SMTP API does not support report mode.

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Setting enforcement mode as disabled for EN by default, as SMTP API does not support report mode.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
