### PR TITLE
fix: fixed icd-apitypes for global deny rule

### DIFF
--- a/examples/fscloud/main.tf
+++ b/examples/fscloud/main.tf
@@ -87,6 +87,10 @@ module "cbr_account_level" {
       "enforcement_mode" = "enabled"
       "global_deny"      = false # mandatory to set 'global_deny = false' when no scope is defined
     }
+    "databases-for-postgresql" = {
+      "enforcement_mode" = "enabled"
+      "target_rg"        = module.resource_group.resource_group_id
+    }
     "messagehub" = {
       # As the service is scoped, a new global rule will also get created
       "enforcement_mode" = "enabled"

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -448,7 +448,17 @@ module "global_deny_cbr_rule" {
   rule_description = try(each.value.description, null) != null ? each.value.description : "${var.prefix}-${each.key}-global-deny-rule"
   enforcement_mode = each.value.enforcement_mode
   rule_contexts    = []
-
+  operations = (length(lookup(local.operations_apitype_val, each.key, [])) > 0) ? [{
+    api_types = [
+      # lookup the map for the target service name, if empty then pass default value
+      for apitype in lookup(local.operations_apitype_val, each.key, []) : {
+        api_type_id = apitype
+    }]
+    }] : [{
+    api_types = [{
+      api_type_id = "crn:v1:bluemix:public:context-based-restrictions::::api-type:"
+    }]
+  }]
   resources = [{
     tags = try(each.value.tags, null) != null ? [for tag in each.value.tags : {
       name  = split(":", tag)[0]


### PR DESCRIPTION
### Description

Fixed icd-apitypes for global deny rule
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/517)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

-  Fixed valid API types for all ICD services.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
