### PR TITLE
feat: cos enf mode enabled and SCC to COS added

### DIFF
--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -5,13 +5,13 @@ This module creates default coarse-grained CBR rules in a given account followin
 - Block Storage -> Hyper Protect Crypto Services (HPCS)
 - IBM Cloud Kubernetes Service (IKS) -> Hyper Protect Crypto Services (HPCS)
 - All IBM Cloud Databases (ICD) services -> Hyper Protect Crypto Services (HPCS)
-- Activity Tracker route -> Cloud Object Storage (COS)
-- Virtual Private Clouds (VPCs) where clusters are deployed -> Cloud Object Storage (COS)
-- IBM Cloud VPC Infrastructure Services (IS) -> Cloud Object Storage (COS)
-- Virtual Private Clouds (VPCs) workload (eg: Kubernetes worker nodes) -> IBM Cloud Container Registry
-- IBM Cloud Databases (ICD) -> Hyper Protect Crypto Services (HPCS)
-- IBM Cloud Kubernetes Service (IKS) -> VPC Infrastructure Services (IS)
 - Event Streams (Messagehub) -> Hyper Protect Crypto Services (HPCS)
+- Virtual Private Clouds (VPCs) where clusters are deployed -> Cloud Object Storage (COS)
+- Activity Tracker route -> Cloud Object Storage (COS)
+- IBM Cloud VPC Infrastructure Services (IS) -> Cloud Object Storage (COS)
+- Security and Compliance Center (SCC) -> Cloud Object Storage (COS)
+- Virtual Private Clouds (VPCs) workload (eg: Kubernetes worker nodes) -> IBM Cloud Container Registry
+- IBM Cloud Kubernetes Service (IKS) -> VPC Infrastructure Services (IS)
 
 
 **Note on KMS**: the module supports setting up rules for Key Protect, and Hyper Protect Crypto Services. By default the modules set rules for Hyper Protect Crypto Services, but this can be modified to use Key Protect, Hyper Protect, or both Key Protect and Hyper Protect Crypto Services using the input variable `kms_service_targeted_by_prewired_rules`.
@@ -120,6 +120,7 @@ module "cbr_fscloud" {
 | <a name="input_allow_iks_to_is"></a> [allow\_iks\_to\_is](#input\_allow\_iks\_to\_is) | Set rule for IKS to IS (VPC Infrastructure Services), default is true | `bool` | `true` | no |
 | <a name="input_allow_is_to_cos"></a> [allow\_is\_to\_cos](#input\_allow\_is\_to\_cos) | Set rule for IS (VPC Infrastructure Services) to COS, default is true | `bool` | `true` | no |
 | <a name="input_allow_roks_to_kms"></a> [allow\_roks\_to\_kms](#input\_allow\_roks\_to\_kms) | Set rule for ROKS to KMS, default is true | `bool` | `true` | no |
+| <a name="input_allow_scc_to_cos"></a> [allow\_scc\_to\_cos](#input\_allow\_scc\_to\_cos) | Set rule for SCC (Security and Compliance Center) to COS, default is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_container_registry"></a> [allow\_vpcs\_to\_container\_registry](#input\_allow\_vpcs\_to\_container\_registry) | Set rule for VPCs to container registry, default is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_cos"></a> [allow\_vpcs\_to\_cos](#input\_allow\_vpcs\_to\_cos) | Set rule for VPCs to COS, default is true | `bool` | `true` | no |
 | <a name="input_custom_rule_contexts_by_service"></a> [custom\_rule\_contexts\_by\_service](#input\_custom\_rule\_contexts\_by\_service) | Any additional context to add to the CBR rules created by this module. The context are added to the CBR rule targetting the service passed as a key. The module looks up the zone id when service\_ref\_names or add\_managed\_vpc\_zone are passed in. | <pre>map(list(object(<br>    {<br>      endpointType = string # "private, public or direct"<br><br>      # Service-name (module lookup for existing network zone) and/or CBR zone id<br>      service_ref_names    = optional(list(string), [])<br>      add_managed_vpc_zone = optional(bool, false)<br>      zone_ids             = optional(list(string), [])<br>  })))</pre> | `{}` | no |

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -22,7 +22,7 @@ locals {
       "enforcement_mode" : "report"
     },
     "cloud-object-storage" : {
-      "enforcement_mode" : "report"
+      "enforcement_mode" : "enabled"
     },
     "codeengine" : {
       "enforcement_mode" : "report"
@@ -246,6 +246,8 @@ locals {
   is_cbr_zone_id = local.cbr_zones["is"].zone_id
   # tflint-ignore: terraform_naming_convention
   event_streams_cbr_zone_id = local.cbr_zones["messagehub"].zone_id
+  # tflint-ignore: terraform_naming_convention
+  scc_cbr_zone_id = local.cbr_zones["compliance"].zone_id
 
   prewired_rule_contexts_by_service = merge({
     # COS -> HPCS, Block storage -> HPCS, ROKS -> HPCS, ICD -> HPCS, Event Streams (Messagehub) -> HPCS
@@ -266,7 +268,7 @@ locals {
         var.allow_event_streams_to_kms ? [local.event_streams_cbr_zone_id] : []
       ])
     }] }, {
-    # Fs VPCs -> COS, AT -> COS, VPC Infrastructure Services (IS) -> COS
+    # Fs VPCs -> COS, AT -> COS, VPC Infrastructure Services (IS) -> COS, Security and Compliance Center (SCC) -> COS
     "cloud-object-storage" : [{
       endpointType : "direct",
       networkZoneIds : flatten([
@@ -276,7 +278,8 @@ locals {
       endpointType : "private",
       networkZoneIds : flatten([
         var.allow_at_to_cos ? [local.logdnaat_cbr_zone_id] : [],
-        var.allow_is_to_cos ? [local.is_cbr_zone_id] : []
+        var.allow_is_to_cos ? [local.is_cbr_zone_id] : [],
+        var.allow_scc_to_cos ? [local.scc_cbr_zone_id] : [],
       ])
     }] }, {
     # VPCs -> container registry

--- a/modules/fscloud/variables.tf
+++ b/modules/fscloud/variables.tf
@@ -69,6 +69,12 @@ variable "allow_is_to_cos" {
   default     = true
 }
 
+variable "allow_scc_to_cos" {
+  type        = bool
+  description = "Set rule for SCC (Security and Compliance Center) to COS, default is true"
+  default     = true
+}
+
 variable "zone_service_ref_list" {
   type = object({
     cloud-object-storage = optional(object({


### PR DESCRIPTION
### Description

Added SCC network zone in the COS rule context to allow traffic flow from SCC -> COS and enforcement mode is set to enabled for COS rule.

[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/523)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

- Allowed traffic from SCC to COS with private endpoint.
- COS rule enforcement mode is set to enabled by default.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
