### PR TITLE
feat: prewired added for vpc->iam access mgmt and iam groups

### DIFF
--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -7,6 +7,8 @@ This module creates default coarse-grained CBR rules in a given account followin
 - All IBM Cloud Databases (ICD) services -> Hyper Protect Crypto Services (HPCS)
 - Event Streams (Messagehub) -> Hyper Protect Crypto Services (HPCS)
 - Virtual Private Clouds (VPCs) where clusters are deployed -> Cloud Object Storage (COS)
+- Virtual Private Clouds (VPCs) where clusters are deployed -> IAM groups
+- Virtual Private Clouds (VPCs) where clusters are deployed -> IAM access management
 - Activity Tracker route -> Cloud Object Storage (COS)
 - IBM Cloud VPC Infrastructure Services (IS) -> Cloud Object Storage (COS)
 - Security and Compliance Center (SCC) -> Cloud Object Storage (COS)
@@ -125,6 +127,8 @@ module "cbr_fscloud" {
 | <a name="input_allow_scc_to_cos"></a> [allow\_scc\_to\_cos](#input\_allow\_scc\_to\_cos) | Set rule for SCC (Security and Compliance Center) to COS, default is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_container_registry"></a> [allow\_vpcs\_to\_container\_registry](#input\_allow\_vpcs\_to\_container\_registry) | Set rule for VPCs to container registry, default is true | `bool` | `true` | no |
 | <a name="input_allow_vpcs_to_cos"></a> [allow\_vpcs\_to\_cos](#input\_allow\_vpcs\_to\_cos) | Set rule for VPCs to COS, default is true | `bool` | `true` | no |
+| <a name="input_allow_vpcs_to_iam_access_management"></a> [allow\_vpcs\_to\_iam\_access\_management](#input\_allow\_vpcs\_to\_iam\_access\_management) | Set rule for VPCs to IAM access management, default is true | `bool` | `true` | no |
+| <a name="input_allow_vpcs_to_iam_groups"></a> [allow\_vpcs\_to\_iam\_groups](#input\_allow\_vpcs\_to\_iam\_groups) | Set rule for VPCs to IAM groups, default is true | `bool` | `true` | no |
 | <a name="input_custom_rule_contexts_by_service"></a> [custom\_rule\_contexts\_by\_service](#input\_custom\_rule\_contexts\_by\_service) | Any additional context to add to the CBR rules created by this module. The context are added to the CBR rule targetting the service passed as a key. The module looks up the zone id when service\_ref\_names or add\_managed\_vpc\_zone are passed in. | <pre>map(list(object(<br/>    {<br/>      endpointType = string # "private, public or direct"<br/><br/>      # Service-name (module lookup for existing network zone) and/or CBR zone id<br/>      service_ref_names    = optional(list(string), [])<br/>      add_managed_vpc_zone = optional(bool, false)<br/>      zone_ids             = optional(list(string), [])<br/>  })))</pre> | `{}` | no |
 | <a name="input_existing_cbr_zone_vpcs"></a> [existing\_cbr\_zone\_vpcs](#input\_existing\_cbr\_zone\_vpcs) | Provide a existing zone id for VPC | <pre>object(<br/>    {<br/>      zone_id = string<br/>  })</pre> | `null` | no |
 | <a name="input_existing_serviceref_zone"></a> [existing\_serviceref\_zone](#input\_existing\_serviceref\_zone) | Provide a valid service reference and existing zone id | <pre>map(object(<br/>    {<br/>      zone_id = string<br/>  }))</pre> | `{}` | no |

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -296,7 +296,23 @@ locals {
         var.allow_iks_to_is ? [local.containers-kubernetes_cbr_zone_id] : []
       ])
     }]
-  })
+    }, {
+    # VPCs -> iam-groups
+    "iam-groups" : [{
+      endpointType : "private",
+      networkZoneIds : flatten([
+        var.allow_vpcs_to_iam_groups ? [local.cbr_zone_vpcs.zone_id] : [],
+      ])
+    }] }, {
+    # VPCs -> iam-access-management
+    "iam-access-management" : [{
+      endpointType : "private",
+      networkZoneIds : flatten([
+        var.allow_vpcs_to_iam_access_management ? [local.cbr_zone_vpcs.zone_id] : [],
+      ])
+    }]
+    }
+  )
 
   prewired_rule_contexts_by_service_check = { for key, value in local.prewired_rule_contexts_by_service :
     key => [

--- a/modules/fscloud/variables.tf
+++ b/modules/fscloud/variables.tf
@@ -51,6 +51,17 @@ variable "allow_vpcs_to_cos" {
   default     = true
 }
 
+variable "allow_vpcs_to_iam_groups" {
+  type        = bool
+  description = "Set rule for VPCs to IAM groups, default is true"
+  default     = true
+}
+
+variable "allow_vpcs_to_iam_access_management" {
+  type        = bool
+  description = "Set rule for VPCs to IAM access management, default is true"
+  default     = true
+}
 variable "allow_at_to_cos" {
   type        = bool
   description = "Set rule for Activity Tracker to COS, default is true"


### PR DESCRIPTION
### Description

Pre-wired rule added for VPCs -> IAM access management and VPCs -> IAM groups for SCC scan to pass, refer screenshot below.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/536)

![Image](https://media.github.ibm.com/user/410235/files/e87ae7d7-641b-4894-9926-b4464a4e1fd6)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [x] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Prewired CBR rule added for -
VPCs -> IAM access management
VPCs -> IAM groups

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
