### PR TITLE
fix: restrict codeengine control plane api

### DIFF
--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -372,6 +372,10 @@ locals {
   # Some services have restrictions on the api types that can apply CBR - we codify this below
   # Restrict and allow the api types as per the target service
   icd_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:data-plane"]
+
+  # Restrict Code Engine Control Plane API
+  code_engine_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"]
+
   operations_apitype_val = {
     databases-for-enterprisedb       = local.icd_api_types,
     containers-kubernetes            = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster", "crn:v1:bluemix:public:containers-kubernetes::::api-type:management"],
@@ -386,6 +390,7 @@ locals {
     messages-for-rabbitmq            = local.icd_api_types,
     databases-for-mysql              = local.icd_api_types
     mqcloud                          = local.icd_api_types
+    codeengine                       = local.code_engine_api_types
   }
 
   fake_service_names = {

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -24,10 +24,13 @@ locals {
     "cloud-object-storage" : {
       "enforcement_mode" : "report"
     },
-    "code-engine-service-control-plane" : {
+    "codeengine" : {
       "enforcement_mode" : "report"
     },
-    "code-engine-platform" : {
+    "codeengine-service-control-plane" : {
+      "enforcement_mode" : "report"
+    },
+    "codeengine-platform" : {
       "enforcement_mode" : "report"
     },
     "container-registry" : {
@@ -71,6 +74,9 @@ locals {
     },
     "hs-crypto" : {
       "enforcement_mode" : "report"
+    },
+    "containers-kubernetes" : {
+      "enforcement_mode" : "disabled"
     },
     "containers-kubernetes-management" : {
       "enforcement_mode" : "disabled"
@@ -376,28 +382,29 @@ locals {
   # Restrict and allow the api types as per the target service
   icd_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:data-plane"]
   operations_apitype_val = {
-    databases-for-enterprisedb        = local.icd_api_types,
-    containers-kubernetes             = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster", "crn:v1:bluemix:public:containers-kubernetes::::api-type:management"],
-    containers-kubernetes-cluster     = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster"],
-    containers-kubernetes-management  = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:management"]
-    databases-for-cassandra           = local.icd_api_types,
-    databases-for-elasticsearch       = local.icd_api_types,
-    databases-for-etcd                = local.icd_api_types,
-    databases-for-mongodb             = local.icd_api_types,
-    databases-for-postgresql          = local.icd_api_types,
-    databases-for-redis               = local.icd_api_types,
-    messages-for-rabbitmq             = local.icd_api_types,
-    databases-for-mysql               = local.icd_api_types
-    mqcloud                           = local.icd_api_types
-    code-engine-service-control-plane = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"]
-    code-engine-platform              = ["crn:v1:bluemix:public:context-based-restrictions::::platform-api-type:"]
+    databases-for-enterprisedb       = local.icd_api_types,
+    containers-kubernetes            = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster", "crn:v1:bluemix:public:containers-kubernetes::::api-type:management"],
+    containers-kubernetes-cluster    = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster"],
+    containers-kubernetes-management = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:management"]
+    databases-for-cassandra          = local.icd_api_types,
+    databases-for-elasticsearch      = local.icd_api_types,
+    databases-for-etcd               = local.icd_api_types,
+    databases-for-mongodb            = local.icd_api_types,
+    databases-for-postgresql         = local.icd_api_types,
+    databases-for-redis              = local.icd_api_types,
+    messages-for-rabbitmq            = local.icd_api_types,
+    databases-for-mysql              = local.icd_api_types
+    mqcloud                          = local.icd_api_types
+    codeengine                       = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane", "crn:v1:bluemix:public:context-based-restrictions::::platform-api-type:"]
+    codeengine-service-control-plane = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"]
+    codeengine-platform              = ["crn:v1:bluemix:public:context-based-restrictions::::platform-api-type:"]
   }
 
   fake_service_names = {
-    "containers-kubernetes-cluster"     = "containers-kubernetes",
-    "containers-kubernetes-management"  = "containers-kubernetes"
-    "code-engine-service-control-plane" = "codeengine"
-    "code-engine-platform"              = "codeengine"
+    "containers-kubernetes-cluster"    = "containers-kubernetes",
+    "containers-kubernetes-management" = "containers-kubernetes"
+    "codeengine-service-control-plane" = "codeengine"
+    "codeengine-platform"              = "codeengine"
   }
 }
 

--- a/modules/fscloud/main.tf
+++ b/modules/fscloud/main.tf
@@ -24,7 +24,10 @@ locals {
     "cloud-object-storage" : {
       "enforcement_mode" : "report"
     },
-    "codeengine" : {
+    "code-engine-service-control-plane" : {
+      "enforcement_mode" : "report"
+    },
+    "code-engine-platform" : {
       "enforcement_mode" : "report"
     },
     "container-registry" : {
@@ -372,30 +375,29 @@ locals {
   # Some services have restrictions on the api types that can apply CBR - we codify this below
   # Restrict and allow the api types as per the target service
   icd_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:data-plane"]
-
-  # Restrict Code Engine Control Plane API
-  code_engine_api_types = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"]
-
   operations_apitype_val = {
-    databases-for-enterprisedb       = local.icd_api_types,
-    containers-kubernetes            = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster", "crn:v1:bluemix:public:containers-kubernetes::::api-type:management"],
-    containers-kubernetes-cluster    = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster"],
-    containers-kubernetes-management = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:management"]
-    databases-for-cassandra          = local.icd_api_types,
-    databases-for-elasticsearch      = local.icd_api_types,
-    databases-for-etcd               = local.icd_api_types,
-    databases-for-mongodb            = local.icd_api_types,
-    databases-for-postgresql         = local.icd_api_types,
-    databases-for-redis              = local.icd_api_types,
-    messages-for-rabbitmq            = local.icd_api_types,
-    databases-for-mysql              = local.icd_api_types
-    mqcloud                          = local.icd_api_types
-    codeengine                       = local.code_engine_api_types
+    databases-for-enterprisedb        = local.icd_api_types,
+    containers-kubernetes             = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster", "crn:v1:bluemix:public:containers-kubernetes::::api-type:management"],
+    containers-kubernetes-cluster     = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:cluster"],
+    containers-kubernetes-management  = ["crn:v1:bluemix:public:containers-kubernetes::::api-type:management"]
+    databases-for-cassandra           = local.icd_api_types,
+    databases-for-elasticsearch       = local.icd_api_types,
+    databases-for-etcd                = local.icd_api_types,
+    databases-for-mongodb             = local.icd_api_types,
+    databases-for-postgresql          = local.icd_api_types,
+    databases-for-redis               = local.icd_api_types,
+    messages-for-rabbitmq             = local.icd_api_types,
+    databases-for-mysql               = local.icd_api_types
+    mqcloud                           = local.icd_api_types
+    code-engine-service-control-plane = ["crn:v1:bluemix:public:context-based-restrictions::::api-type:control-plane"]
+    code-engine-platform              = ["crn:v1:bluemix:public:context-based-restrictions::::platform-api-type:"]
   }
 
   fake_service_names = {
-    "containers-kubernetes-cluster"    = "containers-kubernetes",
-    "containers-kubernetes-management" = "containers-kubernetes"
+    "containers-kubernetes-cluster"     = "containers-kubernetes",
+    "containers-kubernetes-management"  = "containers-kubernetes"
+    "code-engine-service-control-plane" = "codeengine"
+    "code-engine-platform"              = "codeengine"
   }
 }
 


### PR DESCRIPTION
### Description

Code Engine has recently introduced restrictions on the Data Plane API as well. To ensure that the restriction applies only to the Control Plane API, this must be explicitly specified in the code.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/638)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added support to explicitly restrict access to only Control Plane API.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
