### PR TITLE
fix: restrict codeengine control plane and dataplane apis

### DIFF
--- a/modules/fscloud/README.md
+++ b/modules/fscloud/README.md
@@ -34,6 +34,8 @@ Important: In order to avoid unexpected breakage in the account against which th
 
 **Note on `Security and Compliance Center (SCC) scan`**: Compliance can only be claimed after all the enforcement mode have been set to enabled.
 
+**Note on `Code Engine`**: Code Engine service does not support restrictions on the `public` endpoint of the `data-plane' API type. To make sure both Contol Plane and Data Plane APIs are restricted, public endpoint in Code Engine CBR context has been added to allow public requests.
+
 ## Note
 The services 'directlink', 'globalcatalog-collection', 'iam-groups' and 'user-management' do not support restriction per location.
 


### PR DESCRIPTION
### Description

Restrict both Code Engine's Control Plane and Data Plane APIs.
[Git Issue](https://github.com/terraform-ibm-modules/terraform-ibm-cbr/issues/638)

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [x] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

Added support to explicitly restrict access to only Control Plane API.

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
