### PR TITLE
fix: add capability to add existing rule_contexts in CBR rules

### DIFF
--- a/solutions/fully-configurable/main.tf
+++ b/solutions/fully-configurable/main.tf
@@ -62,8 +62,7 @@ module "cbr_rule" {
   for_each         = var.cbr_rules
   source           = "../../modules/cbr-rule-module"
   rule_description = each.value.rule_description
-  # rule_contexts    = concat(local.rule_zone_contexts[each.key], each.value.rule_contexts)
-  rule_contexts    = local.rule_zone_contexts[each.key]
+  rule_contexts    = concat(local.rule_zone_contexts[each.key], each.value.rule_contexts)
   enforcement_mode = each.value.enforcement_mode
   resources        = each.value.resources
   operations       = each.value.operations

--- a/solutions/fully-configurable/outputs.tf
+++ b/solutions/fully-configurable/outputs.tf
@@ -4,10 +4,10 @@
 
 output "network_zone_ids" {
   value       = local.cbr_zone_ids
-  description = "Array of all the CBR rules created"
+  description = "Array of all the CBR zones created"
 }
 
 output "cbr_rule_ids" {
   value       = local.cbr_rule_ids
-  description = "Array of all the CBR zones created"
+  description = "Array of all the CBR rules created"
 }


### PR DESCRIPTION
### Description

<!--- Replace this text with a summary of the changes in this PR. Include why the changes are needed and context about the changes. List required dependencies. If there is a Git issue for the change, please link to it. --->

This PR adds support to add existing `rule_contexts` in CBR rules and minor changes in description of output variables

### Release required?
<!--- Identify the type of release. For information about the changes in a semantic versioning release, see [Release versioning](https://terraform-ibm-modules.github.io/documentation/#/versioning). --->

- [ ] No release
- [ ] Patch release (`x.x.X`)
- [ ] Minor release (`x.X.x`)
- [ ] Major release (`X.x.x`)

##### Release notes content

<!--- If a release is required, replace this text with information that users need to know about the release. Write the release notes to help users understand the changes, and include information about how to update from the previous version.

Your notes help the merger write the commit message for the PR that is published in the release notes for the module. --->

### Run the pipeline

If the CI pipeline doesn't run when you create the PR, the PR requires a user with GitHub collaborators access to run the pipeline.

Run the CI pipeline when the PR is ready for review and you expect tests to pass. Add a comment to the PR with the following text:

```
/run pipeline
```

### Checklist for reviewers

- [ ] If relevant, a test for the change is included or updated with this PR.
- [ ] If relevant, documentation for the change is included or updated with this PR.

### For mergers

- Use a conventional commit message to set the release level. Follow the [guidelines](https://terraform-ibm-modules.github.io/documentation/#/merging.md).
- Include information that users need to know about the PR in the commit message. The commit message becomes part of the GitHub release notes.
- Use the **Squash and merge** option.
